### PR TITLE
Fix drizzle initialization

### DIFF
--- a/OcrIntelligence/OcrIntelligence/db/index.ts
+++ b/OcrIntelligence/OcrIntelligence/db/index.ts
@@ -13,4 +13,4 @@ if (!process.env.DATABASE_URL) {
 }
 
 export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-export const db = drizzle({ client: pool, schema });
+export const db = drizzle(pool, { schema });


### PR DESCRIPTION
## Summary
- fix drizzle initialization typo

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_683f5072ccf48332a7018700d8d11401